### PR TITLE
Check for undefined before firing

### DIFF
--- a/src/Render.js
+++ b/src/Render.js
@@ -74,6 +74,8 @@ class DispatchBuffer {
     return Promise.all(this.promisesBuffer).then((data) => {
       // fire off all the actions synchronously
       data.forEach((f) => {
+        if (!f) return;
+        
         if (Array.isArray(f)) {
           f.forEach(x => x())
         } else {


### PR DESCRIPTION
The resolved data may be undefined depending on use case. Might be better to check for null/undefined before executing.
