### PR TITLE
Add afterSetState hook to connectToStores

### DIFF
--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -16,7 +16,7 @@
  *        getPropsFromStores(props) {
  *          return myStore.getState()
  *        },
- *        afterSetState(props) {
+ *        storeDidChange(props) {
  *          // Optional: do something after the state has been set
  *        }
  *      },
@@ -58,12 +58,12 @@ function connectToStores(Spec, Component = Spec) {
     throw new Error('connectToStores() expects the wrapped component to have a static getPropsFromStores() method')
   }
 
-  if (typeof Spec.afterSetState === 'undefined'){
-    var afterSetState = (...args) => {} // no-op
-  } else if (!isFunction(Spec.afterSetState)) {
-    throw new Error('connectToStores() expects the afterSetState() to be a function')
+  if (typeof Spec.storeDidChange === 'undefined'){
+    var storeDidChange = (...args) => {} // no-op
+  } else if (!isFunction(Spec.storeDidChange)) {
+    throw new Error('connectToStores() expects the storeDidChange() to be a function')
   } else {
-    var afterSetState = Spec.afterSetState
+    var storeDidChange = Spec.storeDidChange
   }
 
   const StoreConnection = React.createClass({
@@ -93,7 +93,7 @@ function connectToStores(Spec, Component = Spec) {
 
     onChange() {
       this.setState(Spec.getPropsFromStores(this.props, this.context))
-      afterSetState(this.props, this.context)
+      storeDidChange(this.props, this.context)
     },
 
     render() {

--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -15,6 +15,9 @@
  *        },
  *        getPropsFromStores(props) {
  *          return myStore.getState()
+ *        },
+ *        afterSetState(props) {
+ *          // Optional: do something after the state has been set
  *        }
  *      },
  *      render() {
@@ -55,6 +58,14 @@ function connectToStores(Spec, Component = Spec) {
     throw new Error('connectToStores() expects the wrapped component to have a static getPropsFromStores() method')
   }
 
+  if (typeof Spec.afterSetState === 'undefined'){
+    var afterSetState = (...args) => {} // no-op
+  } else if (!isFunction(Spec.afterSetState)) {
+    throw new Error('connectToStores() expects the afterSetState() to be a function')
+  } else {
+    var afterSetState = Spec.afterSetState
+  }
+
   const StoreConnection = React.createClass({
     displayName: `Stateful${Component.displayName || Component.name || 'Container'}`,
 
@@ -82,6 +93,7 @@ function connectToStores(Spec, Component = Spec) {
 
     onChange() {
       this.setState(Spec.getPropsFromStores(this.props, this.context))
+      afterSetState(this.props, this.context)
     },
 
     render() {

--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -93,7 +93,7 @@ function connectToStores(Spec, Component = Spec) {
 
     onChange() {
       this.setState(Spec.getPropsFromStores(this.props, this.context))
-      storeDidChange(this.props, this.context)
+      storeDidChange(this.state)
     },
 
     render() {

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -257,8 +257,8 @@ export default {
       assert(componentDidConnect === true)
     },
 
-    'afterSetState hook is called '() {
-      let afterSetState = false
+    'storeDidChange hook is called '() {
+      let storeDidChange = false
       class ClassComponent4 extends React.Component {
         render() {
           return <span foo={this.props.foo} />
@@ -271,8 +271,8 @@ export default {
         getPropsFromStores(props) {
           return testStore.getState()
         },
-        afterSetState() {
-          afterSetState = true
+        storeDidChange() {
+          storeDidChange = true
         }
       }, ClassComponent4)
       const node = TestUtils.renderIntoDocument(
@@ -281,7 +281,7 @@ export default {
 
       testActions.updateFoo('Baz')
 
-      assert(afterSetState === true, 'afterSetState() hook not called')
+      assert(storeDidChange === true, 'storeDidChange() hook not called')
     },
 
     'Component receives all updates'(done) {

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -258,7 +258,8 @@ export default {
     },
 
     'storeDidChange hook is called '() {
-      let storeDidChange = false
+      let storeDidChange
+
       class ClassComponent4 extends React.Component {
         render() {
           return <span foo={this.props.foo} />
@@ -271,8 +272,8 @@ export default {
         getPropsFromStores(props) {
           return testStore.getState()
         },
-        storeDidChange() {
-          storeDidChange = true
+        storeDidChange(state) {
+          storeDidChange = state
         }
       }, ClassComponent4)
       const node = TestUtils.renderIntoDocument(
@@ -281,7 +282,7 @@ export default {
 
       testActions.updateFoo('Baz')
 
-      assert(storeDidChange === true, 'storeDidChange() hook not called')
+      assert.deepEqual(storeDidChange, {foo: 'Baz'})
     },
 
     'Component receives all updates'(done) {

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -257,6 +257,33 @@ export default {
       assert(componentDidConnect === true)
     },
 
+    'afterSetState hook is called '() {
+      let afterSetState = false
+      class ClassComponent4 extends React.Component {
+        render() {
+          return <span foo={this.props.foo} />
+        }
+      }
+      const WrappedComponent = connectToStores({
+        getStores() {
+          return [testStore]
+        },
+        getPropsFromStores(props) {
+          return testStore.getState()
+        },
+        afterSetState() {
+          afterSetState = true
+        }
+      }, ClassComponent4)
+      const node = TestUtils.renderIntoDocument(
+        <WrappedComponent />
+      )
+
+      testActions.updateFoo('Baz')
+
+      assert(afterSetState === true, 'afterSetState() hook not called')
+    },
+
     'Component receives all updates'(done) {
       let componentDidConnect = false
       class ClassComponent3 extends React.Component {


### PR DESCRIPTION
Sometimes it is nice to be able to have a method be invoked
whenever the state changes on the object. An example of this might read:

``` js
 class MyComponent extends React.Component {
   static getStores(props) {
     return [myStore]
   }
   static getPropsFromStores(props) {
     return myStore.getState()
   }
   static storeDidChange(props) {
     messenger.notify(props);
   }
   render() {
     // Use this.props like normal ...
   }
 }

 MyComponent = connectToStores(MyComponent)
```
