### PR TITLE
Throw error if addActionListener is missing function as second argument

### DIFF
--- a/src/ActionListeners.js
+++ b/src/ActionListeners.js
@@ -17,6 +17,8 @@
  * ```
  */
 
+import { isFunction } from './functions';
+
 function ActionListeners(alt) {
   this.dispatcher = alt.dispatcher
   this.listeners = {}
@@ -27,6 +29,10 @@ function ActionListeners(alt) {
  * Adds a listener to a specified action and returns the dispatch token.
  */
 ActionListeners.prototype.addActionListener = function addActionListener(symAction, handler) {
+  if (!isFunction(handler)) {
+    throw new Error('addActionListener() expects a function as the second argument')
+  }
+
   const id = this.dispatcher.register((payload) => {
     /* istanbul ignore else */
     if (symAction === payload.action) {

--- a/test/action-listeners-test.js
+++ b/test/action-listeners-test.js
@@ -1,0 +1,19 @@
+import Alt from 'alt'
+import ActionListeners from '../src/ActionListeners'
+import { assert } from 'chai'
+
+export default {
+  'ActionListeners': {
+    'addActionListener': {
+      'adding an action listener'() {
+        const alt = new Alt()
+        const action = alt.generateActions('someAction')
+        const actionListeners = new ActionListeners(alt)
+        assert.throw(
+          () => actionListeners.addActionListener(action.SOME_ACTION, undefined),
+          'addActionListener() expects a function as the second argument'
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/goatslacker/alt/issues/536 / https://github.com/altjs/utils/issues/5.
