### PR TITLE
Allow setting propTypes for the component container created by connec…

### DIFF
--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -107,6 +107,10 @@ function connectToStores(Spec, Component = Spec) {
     StoreConnection.contextTypes = Component.contextTypes
   }
 
+  if (Spec.connectorPropTypes) {
+    StoreConnection.propTypes = Spec.connectorPropTypes
+  }
+
   return StoreConnection
 }
 


### PR DESCRIPTION
…tToStore

Adding a way to set the `propTypes` of `StoreConnection` component returned by `connectToStore`.

I have a real use case for this: I have an `Article` component which takes an article object as props and I'm using `connectToStore` to connect it to an `ArticleStore`. The `StoreConnection` component returned from `connectToStore` takes an `articleID` as its props and uses that to get the article object from store and passes it down to the stateless `Article` component. 

Before this, I can't require this `StoreConnection` to have an `articleID` props. Now with `connectorPropTypes` in `Spec`, it's possible.
