### PR TITLE
copies static methods to HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "react-dom": "0.14.0",
     "rimraf": "2.4.3",
     "sinon": "1.17.1"
+  },
+  "dependencies": {
+    "hoist-non-react-statics": "^1.2.0"
   }
 }

--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -47,6 +47,7 @@
  */
 
 import React from 'react'
+import hoistNonReactStatic from 'hoist-non-react-statics'
 import { assign, isFunction } from './functions'
 
 function connectToStores(Spec, Component = Spec) {
@@ -107,12 +108,11 @@ function connectToStores(Spec, Component = Spec) {
     StoreConnection.contextTypes = Component.contextTypes
   }
 
-  Object.getOwnPropertyNames(Spec).forEach(function (prop) {
-    if (prop === 'getPropsFromStores' || prop === 'getStores') return
-    if (isFunction(Spec[prop]) && !StoreConnection[prop]) {
-      StoreConnection[prop] = Spec[prop]
-    }
+  hoistNonReactStatic(StoreConnection, Spec, {
+    getStores: true,
+    getPropsFromStores: true
   })
+
 
   return StoreConnection
 }

--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -47,7 +47,7 @@
  */
 
 import React from 'react'
-import hoistNonReactStatic from 'hoist-non-react-statics'
+import statics from 'hoist-non-react-statics'
 import { assign, isFunction } from './functions'
 
 function connectToStores(Spec, Component = Spec) {
@@ -108,7 +108,7 @@ function connectToStores(Spec, Component = Spec) {
     StoreConnection.contextTypes = Component.contextTypes
   }
 
-  hoistNonReactStatic(StoreConnection, Spec, {
+  statics(StoreConnection, Spec, {
     getStores: true,
     getPropsFromStores: true
   })

--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -107,6 +107,13 @@ function connectToStores(Spec, Component = Spec) {
     StoreConnection.contextTypes = Component.contextTypes
   }
 
+  Object.getOwnPropertyNames(Spec).forEach(function (prop) {
+    if (prop === 'getPropsFromStores' || prop === 'getStores') return
+    if (isFunction(Spec[prop]) && !StoreConnection[prop]) {
+      StoreConnection[prop] = Spec[prop]
+    }
+  })
+
   return StoreConnection
 }
 

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -91,6 +91,38 @@ export default {
       assert.throws(() => connectToStores(BadComponentOne), 'expects the wrapped component to have a static getStores() method')
     },
 
+    'static methods on wrapped component are copied to StoreConnection component'() {
+
+      let outsideFunction = sinon.spy();
+
+      const ComponentWithStatics = React.createClass({
+        statics: {
+          getStores() {
+            return [testStore]
+          },
+          getPropsFromStores(props) {
+            return testStore.getState()
+          },
+          foo() {
+            outsideFunction()
+          }
+        },
+        render() {
+          return React.createElement('div', null, 'statics')
+        }
+      })
+
+      const wrappedComponent = connectToStores(ComponentWithStatics)
+
+
+      assert.isFunction(wrappedComponent.foo, 'expects foo to also be a function on the wrapped component')
+      assert.isNotFunction(wrappedComponent.getPropsFromStores, 'expects getPropsFromStores to not be copied')
+      assert.isNotFunction(wrappedComponent.getStores, 'expects getStores to not be copied')
+
+      wrappedComponent.foo()
+      assert.strictEqual(outsideFunction.called, true, 'expects the funtion outside to have been called')
+    },
+
     'element mounts and unmounts'() {
       const div = document.createElement('div')
 

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -120,7 +120,7 @@ export default {
       assert.isNotFunction(wrappedComponent.getStores, 'expects getStores to not be copied')
 
       wrappedComponent.foo()
-      assert.strictEqual(outsideFunction.called, true, 'expects the funtion outside to have been called')
+      assert.strictEqual(outsideFunction.called, true, 'expects the function outside to have been called')
     },
 
     'element mounts and unmounts'() {


### PR DESCRIPTION
this copies static methods on the component class sent to connect to stores. this would be valuable for components that are at the top level, and in an SPA you may want to call fetch for server side rendering from a pre-defined method. this makes no assumptions on what the name of that method should be. you may also just want to call the fetch method before rendering, and being able to specify that in the component is nice. 
