### PR TITLE
Add getRef() method to connectToStores to expose wrapped component

### DIFF
--- a/src/connectToStores.js
+++ b/src/connectToStores.js
@@ -91,6 +91,10 @@ function connectToStores(Spec, Component = Spec) {
       this.storeListeners.forEach(unlisten => unlisten())
     },
 
+    getRef() {
+      return this.refs.component
+    },
+
     onChange() {
       this.setState(Spec.getPropsFromStores(this.props, this.context))
       storeDidChange(this.state)
@@ -99,7 +103,7 @@ function connectToStores(Spec, Component = Spec) {
     render() {
       return React.createElement(
         Component,
-        assign({}, this.props, this.state)
+        assign({ ref: 'component' }, this.props, this.state)
       )
     },
   })

--- a/test/connect-to-stores-test.js
+++ b/test/connect-to-stores-test.js
@@ -285,6 +285,32 @@ export default {
       assert.deepEqual(storeDidChange, {foo: 'Baz'})
     },
 
+    'Component ref can be accessed from WrappedComponent'() {
+      class ClassComponent5 extends React.Component {
+        static getStores() {
+          return [testStore]
+        }
+        static getPropsFromStores(props) {
+          return testStore.getState()
+        }
+        isAccessible() {
+          return true
+        }
+        render() {
+          return <span foo={this.props.foo} />
+        }
+      }
+
+      const WrappedComponent = connectToStores(ClassComponent5)
+
+      let node = TestUtils.renderIntoDocument(
+        <WrappedComponent />
+      )
+
+      const child = node.getRef()
+      assert(child.isAccessible() === true)
+    },
+
     'Component receives all updates'(done) {
       let componentDidConnect = false
       class ClassComponent3 extends React.Component {


### PR DESCRIPTION
In the case of [exposed component functions](https://facebook.github.io/react/tips/expose-component-functions.html), connectToStores lacks any way to provide access to them after wrapping the component.  Rather than hoisting static/non-static functions, or something else that would be prone to errors if React/Alt internals change in the future, I just provide a convenience method on the wrapped component that will hand over the ref of the Component.
